### PR TITLE
Handle empty yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 htmlcov
 .pytest_cache
 *.egg-info
+env
+venv
+__pycache__

--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,6 @@ Contribute
 Create virtual environment and install package and dependencies.
 
 .. code:: shell
-    pip install -e .
     pip install -e ".[tests]"
 
 

--- a/README.rst
+++ b/README.rst
@@ -166,3 +166,19 @@ where environment variables are the preferred configuration method.
 This module let's me do things the way I prefer in environments I control, but
 still run them with environment variables on environments I don't control with
 minimal fuss.
+
+
+Contribute
+----------
+
+Create virtual environment and install package and dependencies.
+
+.. code:: shell
+    pip install -e .
+    pip install -e ".[tests]"
+
+
+Run tests
+
+.. code:: shell
+    pytest

--- a/goodconf/__init__.py
+++ b/goodconf/__init__.py
@@ -29,7 +29,7 @@ def _load_config(path: str) -> dict:
         loader = json.load
     with open(path) as f:
         config = loader(f)
-    return config
+    return config or {}
 
 
 def _find_file(filename: str, require: bool = True) -> str:

--- a/tests/test_file_helpers.py
+++ b/tests/test_file_helpers.py
@@ -17,6 +17,13 @@ def test_yaml(tmpdir):
     assert _load_config(str(conf)) == {'a': 'b', 'c': 3}
 
 
+def test_load_empty_yaml(tmpdir):
+    pytest.importorskip('ruamel.yaml')
+    conf = tmpdir.join('conf.yaml')
+    conf.write('')
+    assert _load_config(str(conf)) == {}
+
+
 def test_missing(tmpdir):
     conf = tmpdir.join('test.yml')
     assert _find_file(str(conf), require=False) is None

--- a/tests/test_goodconf.py
+++ b/tests/test_goodconf.py
@@ -97,11 +97,7 @@ def test_dump_yaml():
 
     output = TestConf.generate_yaml()
     output = re.sub(r' +\n', '\n', output)
-    assert dedent("""\
-        #
-        # Configuration for My App
-        #
-        """) in output
+    assert "\n# Configuration for My App\n" in output
     assert dedent("""\
         # this is a
         a: ''


### PR DESCRIPTION
If an empty YAML config file is created, the config data is created as `None`. We have to make sure the return from the `_load_config` is always a dict.