### PR TITLE
Use pydantic settings source for loading files

### DIFF
--- a/goodconf/contrib/django.py
+++ b/goodconf/contrib/django.py
@@ -28,7 +28,7 @@ def load_config_from_cli(config: GoodConf, argv: List[str]) -> List[str]:
         argparser_add_argument(parser, config)
 
         config_arg, default_args = parser.parse_known_args(argv)
-        config.load(config_arg.config)
+        config.from_file(config_arg.config)
         yield default_args
     finally:
         # Put that create_parser back where it came from or so help me!

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -16,7 +16,6 @@ def test_conf_env_var(mocker, tmpdir):
 
     with env_var("CONF", str(path)):
         g = G()
-        g.load()
     mocked_load_config.assert_called_once_with(str(path))
     assert g.Config._config_file == str(path)
 
@@ -34,20 +33,18 @@ def test_conflict(tmpdir):
 
     with env_var("A", "3"):
         g = G()
-        g.load()
     assert g.A == 3
     assert g.B == 2
 
 
 def test_all_env_vars(mocker):
-    mocked_set_values = mocker.patch("goodconf.BaseSettings.__init__")
+    mocked_set_values = mocker.patch("pydantic.env_settings.EnvSettingsSource.__call__")
 
     class G(GoodConf):
         pass
 
     g = G()
-    g.load()
-    mocked_set_values.assert_called_once_with()
+    mocked_set_values.assert_called_once_with(g)
     assert g.Config._config_file is None
 
 
@@ -56,7 +53,7 @@ def test_provided_file(mocker, tmpdir):
     path = tmpdir.join("myapp.json")
     path.write("")
     g = GoodConf()
-    g.load(str(path))
+    g.from_file(str(path))
     mocked_load_config.assert_called_once_with(str(path))
     assert g.Config._config_file == str(path)
 
@@ -72,6 +69,5 @@ def test_default_files(mocker, tmpdir):
             default_files = [str(bad_path), str(path)]
 
     g = G()
-    g.load()
     mocked_load_config.assert_called_once_with(str(path))
     assert g.Config._config_file == str(path)

--- a/tests/test_goodconf.py
+++ b/tests/test_goodconf.py
@@ -3,9 +3,10 @@ from textwrap import dedent
 from typing import Optional
 
 import pytest
+from goodconf import GoodConf
 from pydantic import Field, ValidationError
 
-from goodconf import GoodConf
+from tests.utils import env_var
 
 
 def test_initial():
@@ -124,10 +125,28 @@ def test_required_missing():
     class TestConf(GoodConf):
         a: str = Field()
 
-    c = TestConf()
-
     with pytest.raises(ValidationError):
-        c.load()
+        TestConf()
 
-    with pytest.raises(ValidationError):
-        TestConf(load=True)
+
+def test_set_on_init():
+    class TestConf(GoodConf):
+        a: str = Field()
+
+    val = "test"
+    c = TestConf(a=val)
+    assert c.a == val
+
+
+def test_env_prefix():
+    val = "test"
+
+    class TestConf(GoodConf):
+        a: str = Field()
+
+        class Config:
+            env_prefix = "PREFIX_"
+
+    with env_var("PREFIX_a", val):
+        c = TestConf()
+    assert c.a == val


### PR DESCRIPTION
This is more of the "pydantic way" to do things and restores some functionality that was broken from the `BaseSettings` class (see #10 and #9)

It is a backwards incompatible change. The class is now validated on instantiation. The `load` method has been removed and a class method `from_file` has been added.

* [ ] update docs
* [ ] update changelog
* [ ] make new major release