### PR TITLE
Added support for parsing and writing toml files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,9 @@ defined configuration.
 Installation
 ------------
 
-``pip install goodconf`` or ``pip install goodconf[yaml]`` if
-parsing/generating YAML files is required.
+``pip install goodconf`` or ``pip install goodconf[yaml]`` /
+``pip install goodconf[toml]`` if parsing/generating YAML/TOML
+files is required.
 
 
 Quick Start

--- a/goodconf/__init__.py
+++ b/goodconf/__init__.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 def _load_config(path: str) -> dict:
     """
-    Given a file path, parse it based on its extension (YAML or JSON)
+    Given a file path, parse it based on its extension (YAML, TOML or JSON)
     and return the values as a Python dictionary. JSON is the default if an
     extension can't be determined.
     """
@@ -28,6 +28,12 @@ def _load_config(path: str) -> dict:
 
         yaml = ruamel.yaml.YAML(typ="safe", pure=True)
         loader = yaml.load
+    elif ext == ".toml":
+        import tomlkit
+
+        def loader(f):
+            return tomlkit.load(f).unwrap()
+
     else:
         loader = json.load
     with open(path) as f:
@@ -158,6 +164,15 @@ class GoodConf(BaseSettings):
         Dumps initial config in JSON
         """
         return json.dumps(cls.get_initial(**override), indent=2)
+
+    @classmethod
+    def generate_toml(cls, **override) -> str:
+        """
+        Dumps initial config in TOML
+        """
+        import tomlkit
+
+        return tomlkit.dumps(cls.get_initial(**override))
 
     @classmethod
     def generate_markdown(cls) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,13 @@ exclude = tests
 [options.extras_require]
 yaml =
     ruamel.yaml>=0.17.0
+toml =
+    tomlkit>=0.11.6
+
 tests =
     django==3.2.*
     ruamel.yaml>=0.17.0
+    tomlkit>=0.11.6
     pytest==7.1.*
     pytest-cov==2.5.1
     pytest-mock==1.7.1

--- a/tests/test_file_helpers.py
+++ b/tests/test_file_helpers.py
@@ -11,6 +11,20 @@ def test_json(tmpdir):
     assert _load_config(str(conf)) == {"a": "b", "c": 3}
 
 
+def test_load_toml(tmpdir):
+    pytest.importorskip("tomlkit")
+    conf = tmpdir.join("conf.toml")
+    conf.write('a = "b"\nc = 3')
+    assert _load_config(str(conf)) == {"a": "b", "c": 3}
+
+
+def test_load_empty_toml(tmpdir):
+    pytest.importorskip("tomlkit")
+    conf = tmpdir.join("conf.toml")
+    conf.write("")
+    assert _load_config(str(conf)) == {}
+
+
 def test_yaml(tmpdir):
     pytest.importorskip("ruamel.yaml")
     conf = tmpdir.join("conf.yaml")

--- a/tests/test_goodconf.py
+++ b/tests/test_goodconf.py
@@ -28,6 +28,15 @@ def test_dump_json():
     assert TestConf.generate_json(a=False) == '{\n  "a": false\n}'
 
 
+def test_dump_toml():
+    pytest.importorskip("tomlkit")
+
+    class TestConf(GoodConf):
+        a: bool = Field(initial=lambda: True)
+
+    assert TestConf.generate_toml() == "a = true\n"
+
+
 def test_dump_yaml():
     pytest.importorskip("ruamel.yaml")
 


### PR DESCRIPTION
I would love to use `tomllib` from python3.11 if available, but it doesn't help if one wants to support writing. That said if it were okay to just support reading if `tomlkit` is installed one could use it without extra like `tomlkit`