### PR TITLE
Add a GitHub Action To Auto-Publish On Tag Pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Publish to PyPI
+on:
+  push:
+    branches: [main, test-publish]
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  pypi-publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [build]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/goodconf
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,11 @@ jobs:
       run: pip install hatch
     - name: Build a binary wheel and a source tarball
       run: hatch build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
 
   pypi-publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
@@ -32,10 +37,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: Install hatch
-      run: pip install hatch
-    - name: Build a binary wheel and a source tarball
-      run: hatch build
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -52,10 +58,11 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
-    - name: Install hatch
-      run: pip install hatch
-    - name: Build a binary wheel and a source tarball
-      run: hatch build
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -56,7 +55,6 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v2.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - Install hatch
+    - name: Install hatch
       run: pip install hatch
     - name: Build a binary wheel and a source tarball
       run: hatch build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
     permissions:
       id-token: write
     steps:
+    - name: Install hatch
+      run: pip install hatch
+    - name: Build a binary wheel and a source tarball
+      run: hatch build
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -48,6 +52,10 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
+    - name: Install hatch
+      run: pip install hatch
+    - name: Build a binary wheel and a source tarball
+      run: hatch build
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         gh release create
         '${{ github.ref_name }}'
         --repo '${{ github.repository }}'
-        --notes ""
+        --generate-notes
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
     needs:
-    - publish-to-pypi
+    - pypi-publish
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -52,10 +48,6 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        path: dist/
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+    - Install hatch
+      run: pip install hatch
     - name: Build a binary wheel and a source tarball
       run: hatch build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,19 +16,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
     - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      run: hatch build
 
   pypi-publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+
+4.0.3 (13 August 2024)
+========================
+
+- Release from GitHub Actions
+
 4.0.2 (11 February 2024)
 ========================
 

--- a/README.rst
+++ b/README.rst
@@ -194,14 +194,5 @@ Run tests
 
     pytest
 
-Releasing a new version to PyPI:
-
-.. code:: shell
-
-    export VERSION=X.Y.Z
-    git tag -s v$VERSION -m v$VERSION
-    git push --tags
-    rm -rf ./dist
-    hatch build
-    hatch publish --user __token__
-    gh release create v$VERSION dist/goodconf-$VERSION* --generate-notes --verify-tag
+Releases are done with GitHub Actions whenever a new tag is created. For more information,
+see `<./.github/workflows/build.yml>`_


### PR DESCRIPTION
Following the [instructions from python.org](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), this pull request adds a GitHub Action that:
 - builds on all pull requests and pushes to the `main` branch
 - releases on all tag pushes to the `main` branch

Note: in testing this code, I've already released version 4.0.3. See:
 - the GitHub Action run: https://github.com/lincolnloop/goodconf/actions/runs/10375142947
 - the release on PyPI: https://pypi.org/project/goodconf/#history
 - the release on GitHub: https://github.com/lincolnloop/goodconf/releases