### PR TITLE
 Fix Markdown Generation Differences From V4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+5.0.1 (Unreleased)
+========================
+
+- Update Markdown generation, so that output matches v4 output
+
 5.0.0 (13 August 2024)
 ========================
 

--- a/goodconf/__init__.py
+++ b/goodconf/__init__.py
@@ -93,6 +93,25 @@ def _find_file(filename: str, require: bool = True) -> str | None:
     return os.path.abspath(filename)
 
 
+def _annotation_to_str(annotation: type[Any]) -> str:
+    """
+    Return the string representation of a pydantic.fields.FieldInfo annotation.
+    """
+    if isinstance(annotation, type) and not isinstance(annotation, GenericAlias):
+        # For annotation like <class 'int'>, we use its name ("int").
+        field_type = annotation.__name__
+    else:
+        if str(annotation).startswith("typing."):
+            # For annotation like typing.Literal['a', 'b'], we use
+            # its string representation, but without "typing." ("Literal['a', 'b']").
+            field_type = str(annotation)[len("typing.") :]
+        else:
+            # For annotation like list[str], we use its string
+            # representation ("list[str]").
+            field_type = annotation
+    return field_type
+
+
 def initial_for_field(name: str, field_info: FieldInfo) -> Any:
     try:
         json_schema_extra = field_info.json_schema_extra or {}
@@ -290,18 +309,12 @@ class GoodConf(BaseSettings):
             if field_info.description:
                 lines.append(f"  * description: {field_info.description}")
             # We want to append a line with the field_info type, and sometimes
-            # field_info.annotation looks the way we want, like
-            # 'typing.Literal['a', 'b']', but other times, it includes some extra
-            # text, like '<class 'bool'>'. Therefore, we have some logic to make
-            # the type show up the way we want.
-            field_type = (
-                field_info.annotation.__name__
-                if isinstance(field_info.annotation, type)
-                and not isinstance(field_info.annotation, GenericAlias)
-                else field_info.annotation
-            )
+            # field_info.annotation looks the way we want, like 'list[str]', but
+            # other times, it includes some extra text, like '<class 'bool'>'.
+            # Therefore, we have some logic to make the type show up the way we want.
+            field_type = _annotation_to_str(field_info.annotation)
             lines.append(f"  * type: `{field_type}`")
-            if field_info.default is not None:
+            if field_info.default not in [None, PydanticUndefined]:
                 lines.append(f"  * default: `{field_info.default}`")
         return "\n".join(lines)
 

--- a/goodconf/__init__.py
+++ b/goodconf/__init__.py
@@ -93,22 +93,24 @@ def _find_file(filename: str, require: bool = True) -> str | None:
     return os.path.abspath(filename)
 
 
-def _annotation_to_str(annotation: type[Any]) -> str:
+def _fieldinfo_to_str(field_info: FieldInfo) -> str:
     """
-    Return the string representation of a pydantic.fields.FieldInfo annotation.
+    Return the string representation of a pydantic.fields.FieldInfo.
     """
-    if isinstance(annotation, type) and not isinstance(annotation, GenericAlias):
+    if isinstance(field_info.annotation, type) and not isinstance(
+        field_info.annotation, GenericAlias
+    ):
         # For annotation like <class 'int'>, we use its name ("int").
-        field_type = annotation.__name__
+        field_type = field_info.annotation.__name__
     else:
-        if str(annotation).startswith("typing."):
+        if str(field_info.annotation).startswith("typing."):
             # For annotation like typing.Literal['a', 'b'], we use
             # its string representation, but without "typing." ("Literal['a', 'b']").
-            field_type = str(annotation)[len("typing.") :]
+            field_type = str(field_info.annotation)[len("typing.") :]
         else:
             # For annotation like list[str], we use its string
             # representation ("list[str]").
-            field_type = annotation
+            field_type = field_info.annotation
     return field_type
 
 
@@ -312,7 +314,7 @@ class GoodConf(BaseSettings):
             # field_info.annotation looks the way we want, like 'list[str]', but
             # other times, it includes some extra text, like '<class 'bool'>'.
             # Therefore, we have some logic to make the type show up the way we want.
-            field_type = _annotation_to_str(field_info.annotation)
+            field_type = _fieldinfo_to_str(field_info)
             lines.append(f"  * type: `{field_type}`")
             if field_info.default not in [None, PydanticUndefined]:
                 lines.append(f"  * default: `{field_info.default}`")

--- a/tests/test_goodconf.py
+++ b/tests/test_goodconf.py
@@ -151,10 +151,12 @@ def test_generate_markdown_types():
     class TestConf(GoodConf):
         a: Literal["a", "b"] = Field(default="a")
         b: list[str] = Field()
+        c: None
 
     lines = TestConf.generate_markdown().splitlines()
-    assert "  * type: `typing.Literal['a', 'b']`" in lines
+    assert "  * type: `Literal['a', 'b']`" in lines
     assert "  * type: `list[str]`" in lines
+    assert "default: `PydanticUndefined`" not in str(lines)
 
 
 def test_generate_markdown_required():


### PR DESCRIPTION
Following the release of v5.0.0, generating config values in markdown changed slightly. This pull request updates the markdown generation code so that the output matches the goodconf v4 output.

Closes #47 