### PR TITLE
Support `initial` kwarg in `goodconf.Field`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       PYTHON: ${{ matrix.python }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ htmlcov
 env
 venv
 __pycache__
+uv.lock

--- a/goodconf/__init__.py
+++ b/goodconf/__init__.py
@@ -16,7 +16,7 @@ from types import GenericAlias
 from typing import TYPE_CHECKING, cast, get_args
 
 from pydantic._internal._config import config_keys
-from pydantic.fields import Field, PydanticUndefined
+from pydantic.fields import Field as PydanticField, PydanticUndefined
 from pydantic.main import _object_setattr
 from pydantic_settings import (
     BaseSettings,
@@ -33,6 +33,22 @@ if TYPE_CHECKING:
 __all__ = ["GoodConf", "GoodConfConfigDict", "Field"]
 
 log = logging.getLogger(__name__)
+
+
+def Field(
+    initial=None,
+    json_schema_extra=None,
+    **kwargs,
+):
+    """ """
+    if initial and not callable(initial):
+        val = initial
+        initial = lambda: val
+
+    json_schema_extra = json_schema_extra or {}
+    if initial and isinstance(json_schema_extra, dict):
+        json_schema_extra["initial"] = initial
+    return PydanticField(json_schema_extra=json_schema_extra, **kwargs)
 
 
 class GoodConfConfigDict(SettingsConfigDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ version-file = "goodconf/_version.py"
 source = "vcs"
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-branch"
+addopts = "-s --cov --cov-branch"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from pydantic import ConfigDict
 
@@ -49,7 +51,11 @@ def test_help(mocker, tmpdir, capsys):
     )
     mocked_load_config.assert_called_once_with(str(temp_config))
     output = capsys.readouterr()
-    assert "-C FILE, --config FILE" in output.out
+    if sys.version_info < (3, 13):
+        assert "-C FILE, --config FILE" in output.out
+    else:
+        assert "-C, --config FILE" in output.out
+
     assert "MYAPP_CONF" in output.out
     assert "/etc/myapp.json" in output.out
 

--- a/tests/test_goodconf.py
+++ b/tests/test_goodconf.py
@@ -5,10 +5,10 @@ from textwrap import dedent
 from typing import Optional, List, Literal
 
 import pytest
-from pydantic import Field, ValidationError
+from pydantic import ValidationError
 from pydantic.fields import FieldInfo
 
-from goodconf import GoodConf, FileConfigSettingsSource
+from goodconf import Field, GoodConf, FileConfigSettingsSource
 from tests.utils import env_var
 
 

--- a/tests/test_initial.py
+++ b/tests/test_initial.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import pytest
-
 from goodconf import Field, GoodConf, initial_for_field
 
 from .utils import KEY
@@ -14,12 +12,11 @@ def test_initial():
     assert initial_for_field(KEY, C.model_fields["f"]) == "x"
 
 
-def test_initial_bad():
+def test_initial_converts_to_callable():
     class C(GoodConf):
         f: str = Field(initial="x")
 
-    with pytest.raises(ValueError):
-        initial_for_field(KEY, C.model_fields["f"])
+    assert initial_for_field(KEY, C.model_fields["f"]) == "x"
 
 
 def test_initial_default():


### PR DESCRIPTION
Fixes #43 

- Convert values to callables
- Pass `initial` to json_extra_schema if provided since extra keywords are
  deprecated in pydantic.