### PR TITLE
ci: bump codecov-action to v7.0.0 (fix CLI signature verification)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ (success() || failure()) && matrix.env != 'mypy' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.env }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ (success() || failure()) && matrix.env != 'mypy' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results


### PR DESCRIPTION
v6.0.1 fetches Codecov's old (lost) Keybase signing key, so the CLI download fails GPG verification and the upload step exits 1. v6.0.2/v7.0.0 use the migrated key.